### PR TITLE
fix: correct upload-sarif action path in main-deploy workflow (#112)

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -68,7 +68,7 @@ jobs:
           exit-code: 0
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Corrected the invalid action path `github/-action/upload-sarif@v3` to `github/codeql-action/upload-sarif@v3` in the `main-deploy.yml` workflow.