### PR TITLE
security: upgrade CodeQL Action to v4 (#114)

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -68,7 +68,7 @@ jobs:
           exit-code: 0
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Fixes #114\n\nUpgrade all occurrences of CodeQL Action to v4 to avoid the upcoming deprecation of v3 in December 2026.

- Updated `github/codeql-action/upload-sarif@v3` to `@v4` in `main-deploy.yml`.
- Verified that no other occurrences were found in `pr-quality.yml` or other workflow files.\n\nResolves #114