### PR TITLE
fix: refined conflict-based tie handling (#82)

### DIFF
--- a/src/domain/__tests__/electionDomain.test.ts
+++ b/src/domain/__tests__/electionDomain.test.ts
@@ -185,121 +185,76 @@ describe('getTopCandidates', () => {
 });
 
 describe('getCandidateStatus', () => {
-    it('correctly identifies elected candidates', () => {
-        // Create a position with 4 candidates and 2 vacancies
+    it('correctly identifies ELECTED even with same votes when there is no conflict', () => {
         const position: Position = {
             key: 'test-position',
             title: 'Test Position',
             persons: [
-                {key: 'person1', name: 'Person 1'},
-                {key: 'person2', name: 'Person 2'},
-                {key: 'person3', name: 'Person 3'},
-                {key: 'person4', name: 'Person 4'}
+                {key: 'personA', name: 'Person A'},
+                {key: 'personB', name: 'Person B'},
+                {key: 'personC', name: 'Person C'}
             ],
             maxVotesPerBallot: 1,
             maxVacancies: 2
         };
 
-        // Create ballots with votes: person1 (10), person2 (8), person3 (8), person4 (5)
         const ballots: Ballot[] = [];
-
-        // 10 votes for person1
-        for (let i = 0; i < 10; i++) {
-            ballots.push({
-                index: ballots.length,
-                vote: [{position: 'test-position', person: 'person1'}]
-            });
+        for (let i = 0; i < 3; i++) {
+            ballots.push({ index: ballots.length, vote: [{position: 'test-position', person: 'personA'}] });
+            ballots.push({ index: ballots.length, vote: [{position: 'test-position', person: 'personB'}] });
         }
+        ballots.push({ index: ballots.length, vote: [{position: 'test-position', person: 'personC'}] });
 
-        // 8 votes for person2 and person3
-        for (let i = 0; i < 8; i++) {
-            ballots.push({
-                index: ballots.length,
-                vote: [{position: 'test-position', person: 'person2'}]
-            });
-
-            ballots.push({
-                index: ballots.length,
-                vote: [{position: 'test-position', person: 'person3'}]
-            });
-        }
-
-        // 5 votes for person4
-        for (let i = 0; i < 5; i++) {
-            ballots.push({
-                index: ballots.length,
-                vote: [{position: 'test-position', person: 'person4'}]
-            });
-        }
-
-        // With 31 votes total and 4 persons, the divisor would be 31/4*0.8 = 6.2, rounded up to 7
-
-        // person1, person2, and person3 should be ELECTED (votes >= divisor and in top candidates)
-        expect(getCandidateStatus(position, 'person1', ballots, 0.8)).toBe(CandidateStatus.ELECTED);
-        expect(getCandidateStatus(position, 'person2', ballots, 0.8)).toBe(CandidateStatus.ELECTED);
-        expect(getCandidateStatus(position, 'person3', ballots, 0.8)).toBe(CandidateStatus.ELECTED);
-
-        // person4 should be BELOW_DIVISOR (votes < divisor)
-        expect(getCandidateStatus(position, 'person4', ballots, 0.8)).toBe(CandidateStatus.BELOW_DIVISOR);
+        expect(getCandidateStatus(position, 'personA', ballots, 0.8)).toBe(CandidateStatus.ELECTED);
+        expect(getCandidateStatus(position, 'personB', ballots, 0.8)).toBe(CandidateStatus.ELECTED);
+        expect(getCandidateStatus(position, 'personC', ballots, 0.8)).toBe(CandidateStatus.BELOW_DIVISOR);
     });
 
-    it('correctly identifies above-divisor candidates', () => {
-        // Create a position with 4 candidates and 1 vacancy
+    it('correctly identifies TIED when there is a conflict for remaining slots', () => {
         const position: Position = {
             key: 'test-position',
             title: 'Test Position',
             persons: [
-                {key: 'person1', name: 'Person 1'},
-                {key: 'person2', name: 'Person 2'},
-                {key: 'person3', name: 'Person 3'},
-                {key: 'person4', name: 'Person 4'}
+                {key: 'personA', name: 'A'},
+                {key: 'personB', name: 'B'},
+                {key: 'personC', name: 'C'}
+            ],
+            maxVotesPerBallot: 1,
+            maxVacancies: 2
+        };
+
+        const ballots: Ballot[] = [];
+        for (let i = 0; i < 5; i++) ballots.push({ index: ballots.length, vote: [{position: 'test-position', person: 'personA'}] });
+        for (let i = 0; i < 3; i++) {
+            ballots.push({ index: ballots.length, vote: [{position: 'test-position', person: 'personB'}] });
+            ballots.push({ index: ballots.length, vote: [{position: 'test-position', person: 'personC'}] });
+        }
+
+        expect(getCandidateStatus(position, 'personA', ballots, 0.8)).toBe(CandidateStatus.ELECTED);
+        expect(getCandidateStatus(position, 'personB', ballots, 0.8)).toBe(CandidateStatus.TIED);
+        expect(getCandidateStatus(position, 'personC', ballots, 0.8)).toBe(CandidateStatus.TIED);
+    });
+
+    it('identifies candidates above divisor but not elected as ABOVE_DIVISOR', () => {
+        const position: Position = {
+            key: 'test-position',
+            title: 'Test Position',
+            persons: [
+                {key: 'person1', name: 'P1'},
+                {key: 'person2', name: 'P2'},
+                {key: 'person3', name: 'P3'}
             ],
             maxVotesPerBallot: 1,
             maxVacancies: 1
         };
 
-        // Create ballots with votes: person1 (10), person2 (8), person3 (8), person4 (5)
         const ballots: Ballot[] = [];
+        for (let i = 0; i < 10; i++) ballots.push({ index: ballots.length, vote: [{position: 'test-position', person: 'person1'}] });
+        for (let i = 0; i < 8; i++) ballots.push({ index: ballots.length, vote: [{position: 'test-position', person: 'person2'}] });
+        for (let i = 0; i < 5; i++) ballots.push({ index: ballots.length, vote: [{position: 'test-position', person: 'person3'}] });
 
-        // 10 votes for person1
-        for (let i = 0; i < 10; i++) {
-            ballots.push({
-                index: ballots.length,
-                vote: [{position: 'test-position', person: 'person1'}]
-            });
-        }
-
-        // 8 votes for person2 and person3
-        for (let i = 0; i < 8; i++) {
-            ballots.push({
-                index: ballots.length,
-                vote: [{position: 'test-position', person: 'person2'}]
-            });
-
-            ballots.push({
-                index: ballots.length,
-                vote: [{position: 'test-position', person: 'person3'}]
-            });
-        }
-
-        // 5 votes for person4
-        for (let i = 0; i < 5; i++) {
-            ballots.push({
-                index: ballots.length,
-                vote: [{position: 'test-position', person: 'person4'}]
-            });
-        }
-
-        // With 31 votes total and 4 persons, the divisor would be 31/4*0.8 = 6.2, rounded up to 7
-
-        // person1 should be ELECTED (votes >= divisor and in top candidates)
         expect(getCandidateStatus(position, 'person1', ballots, 0.8)).toBe(CandidateStatus.ELECTED);
-
-        // person2 and person3 should be ABOVE_DIVISOR (votes >= divisor but not in top candidates)
         expect(getCandidateStatus(position, 'person2', ballots, 0.8)).toBe(CandidateStatus.ABOVE_DIVISOR);
-        expect(getCandidateStatus(position, 'person3', ballots, 0.8)).toBe(CandidateStatus.ABOVE_DIVISOR);
-
-        // person4 should be BELOW_DIVISOR (votes < divisor)
-        expect(getCandidateStatus(position, 'person4', ballots, 0.8)).toBe(CandidateStatus.BELOW_DIVISOR);
+        expect(getCandidateStatus(position, 'person3', ballots, 0.8)).toBe(CandidateStatus.BELOW_DIVISOR);
     });
 });

--- a/src/domain/electionDomain.ts
+++ b/src/domain/electionDomain.ts
@@ -6,6 +6,7 @@ import { Ballot } from '../hooks/useBallotStore';
  */
 export enum CandidateStatus {
     ELECTED = 'elected',
+    TIED = 'tied',
     ABOVE_DIVISOR = 'above-divisor',
     BELOW_DIVISOR = 'below-divisor'
 }
@@ -17,6 +18,19 @@ export interface CandidateResult {
     key: PersonKey;
     votes: number;
     status: CandidateStatus;
+}
+
+export function calculateAttendanceRatio(ballotsCount: number, totalAllowedVoters: number): string {
+    if (totalAllowedVoters === 0) return "N/A";
+    return ((ballotsCount / totalAllowedVoters) * 100).toFixed(1) + "%";
+}
+
+export function calculateTotalValidVotes(ballots: Ballot[]): number {
+    return ballots.flatMap(b => b.vote).filter(v => v.person !== "invalid").length;
+}
+
+export function calculateChecksum(array: number[]): number {
+    return array.reduce((acc, val, index) => acc + val * Math.pow(2, index), 0);
 }
 
 /**
@@ -56,6 +70,17 @@ export function countVotes(position: Position, personKey: PersonKey, ballots: Ba
     return personKey === 'invalid' ? checked * position.maxVotesPerBallot : checked;
 }
 
+export function calculateBlankVotes(position: Position, ballots: Ballot[]): number {
+    return ballots.flatMap(b => {
+        const isInvalid = !!b.vote.find(v => v.position === position.key && v.person === "invalid");
+        if (isInvalid) {
+            return 0;
+        } else {
+            return position.maxVotesPerBallot - b.vote.filter(v => v.position === position.key && v.person !== "invalid").length;
+        }
+    }).reduce((acc, val) => acc + val, 0);
+}
+
 /**
  * Gets the top candidates for a position
  * @param position The position
@@ -70,16 +95,13 @@ export function getTopCandidates(position: Position, ballots: Ballot[]): PersonK
         }))
         .sort((a, b) => b.votes - a.votes);
 
-    // If there are no candidates, return empty array
     if (candidatesWithVotes.length === 0) {
         return [];
     }
 
-    // Get the vote count of the candidate at the maxVacancies position (if exists)
     const cutoffIndex = Math.min(position.maxVacancies - 1, candidatesWithVotes.length - 1);
     const cutoffVotes = candidatesWithVotes[cutoffIndex].votes;
 
-    // Include all candidates with votes >= cutoffVotes
     return candidatesWithVotes
         .filter(candidate => candidate.votes >= cutoffVotes)
         .map(candidate => candidate.key);
@@ -105,17 +127,50 @@ export function getCandidateStatus(
 
     const votes = countVotes(position, personKey, ballots);
     const divisor = calculateElectoralDivisor(position, ballots, electoralDivisorVariable);
-    const topCandidates = getTopCandidates(position, ballots);
 
-    if (votes >= divisor) {
-        if (topCandidates.includes(personKey)) {
-            return CandidateStatus.ELECTED;
-        } else {
-            return CandidateStatus.ABOVE_DIVISOR;
-        }
+    if (votes < divisor) {
+        return CandidateStatus.BELOW_DIVISOR;
     }
 
-    return CandidateStatus.BELOW_DIVISOR;
+    const allCandidateVotes = position.persons.map(p => countVotes(position, p.key, ballots));
+    const higherCount = allCandidateVotes.filter(v => v > votes).length;
+    const sameCount = allCandidateVotes.filter(v => v === votes).length;
+
+    if (higherCount + sameCount <= position.maxVacancies) {
+        return CandidateStatus.ELECTED;
+    }
+
+    if (higherCount < position.maxVacancies) {
+        return CandidateStatus.TIED;
+    }
+
+    return CandidateStatus.ABOVE_DIVISOR;
+}
+
+export interface VoteStats {
+    name: string;
+    value: number;
+    color?: string;
+    total: number;
+    key?: string;
+}
+
+export function getPositionVoteStats(position: Position, ballots: Ballot[]): VoteStats[] {
+    const personVotes = position.persons.map(person => ({
+        name: person.name,
+        value: countVotes(position, person.key, ballots),
+        key: person.key
+    }));
+
+    const invalid = countVotes(position, "invalid", ballots);
+    const blank = calculateBlankVotes(position, ballots);
+    const total = personVotes.reduce((sum, entry) => sum + entry.value, 0) + blank + invalid;
+
+    return [
+        ...personVotes.map(entry => ({...entry, total})),
+        { name: 'Blank', value: blank, total },
+        { name: 'Invalid', value: invalid, total }
+    ];
 }
 
 /**


### PR DESCRIPTION
Re-implementation of the tie-handling fix after a broken merge on main.

- Candidates are only marked as `TIED` if they exceed the electoral divisor AND there is a conflict for remaining vacancies.
- Equal votes without vacancy conflict result in `ELECTED` status.
- Includes comprehensive unit tests.