### PR TITLE
UX: Hide focus highlight on Votes page when using mouse/touch (#123)

### DIFF
--- a/src/components/pages/Votes.tsx
+++ b/src/components/pages/Votes.tsx
@@ -62,7 +62,26 @@ export function BallotPosition({
     }
 
     return <>
-        <Grid size={{ xs: 6, sm: 3 }} sx={{ mb: 2, mt: 2, padding: ".6rem", borderRadius: ".3rem" }}
+        <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} sx={{
+            mb: 2,
+            mt: 2,
+            padding: ".6rem",
+            borderRadius: ".3rem",
+            "&.focus:focus-visible": {
+                outline: "2px solid #1976d2",
+                backgroundColor: "rgba(25, 118, 210, 0.04)"
+            },
+            "& .focus-indicator": {
+                display: "none"
+            },
+            "&.focus:focus-visible .focus-indicator": {
+                display: "inline-flex"
+            },
+            "&:not(:focus-visible)": {
+                outline: "none",
+                backgroundColor: "transparent"
+            }
+        }}
               tabIndex={positionTabIndex}
               onFocus={onFocusPosition}
               className={focussed ? "focus" : ""}
@@ -70,7 +89,7 @@ export function BallotPosition({
         >
             <Grid alignItems="center" container>
                 <Grid size={2}>
-                    <Chip label={position.title[0].toLowerCase()} variant="outlined"/>
+                    <Chip label={position.title[0].toLowerCase()} variant="outlined" className="focus-indicator"/>
                 </Grid>
                 <Grid size="grow"><Typography variant="h4">
                     {position.title}
@@ -86,9 +105,7 @@ export function BallotPosition({
             {position.persons.map((person, personIndex) => (
                 <Grid container key={person.key}>
                     <Grid size={2}>
-                        {focussed &&
-                            <Chip label={personIndex + 1} variant="outlined"/>
-                        }
+                        <Chip label={personIndex + 1} variant="outlined" className="focus-indicator"/>
                     </Grid>
                     <Grid size="auto">
                         <FormControlLabel
@@ -106,9 +123,8 @@ export function BallotPosition({
             ))}
             <Grid container>
                 <Grid size={2}>
-                    {focussed &&
-                        <Chip label={'i'} variant="outlined"/>
-                    }</Grid>
+                    <Chip label={'i'} variant="outlined" className="focus-indicator"/>
+                </Grid>
                 <Grid size="auto">
                     <FormControlLabel
                         control={


### PR DESCRIPTION
Fixes #123\n\nImplemented `:focus-visible` to hide highlights for non-keyboard users.