### PR TITLE
fix: correct workflow run context syntax

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -91,5 +91,5 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_VOTE_COUNTER_C8CD5 }}'
           projectId: vote-counter-c8cd5
-          channelId: pr-${{ head_branch }} # This needs logic to get PR number
+          channelId: pr-${{ github.event.workflow_run.head_branch }} # This needs logic to get PR number
           expires: 7d


### PR DESCRIPTION
Fixes the syntax error in `deploy-preview.yml` where `head_branch` was used without the `github.event.workflow_run` prefix.