### PR TITLE
fix: reliable PR detection in deploy workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -21,41 +21,54 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const headRepo = context.payload.workflow_run.head_repository.full_name;
-            const headBranch = context.payload.workflow_run.head_branch;
-            const prs = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head: headRepo + ":" + headBranch,
-              state: 'open'
+            const { owner, repo } = context.repo;
+            const run_id = context.payload.workflow_run.id;
+            
+            // 1. Get the workflow run to find the head_sha
+            const run = await github.rest.actions.getWorkflowRun({
+              owner,
+              repo,
+              run_id
             });
+            
+            const head_sha = run.data.head_sha;
+            console.log(`Searching for PRs with head SHA: ${head_sha}`);
+
+            // 2. Find the PR associated with this SHA
+            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: head_sha
+            });
+            
             if (prs.data.length > 0) {
               const pr = prs.data[0];
+              console.log(`Found PR #${pr.number}`);
               core.setOutput('number', pr.number);
             } else {
-              core.setFailed('No open PR found for this branch');
+              core.setFailed(`No open PR found for SHA: ${head_sha}`);
             }
 
       - uses: actions/checkout@v4
         with:
-          repository: \${{ github.event.workflow_run.head_repository.full_name }}
-          ref: \${{ github.event.workflow_run.head_branch }}
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-          run-id: \${{ github.event.workflow_run.id }}
-          github-token: \${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Unit Report
         uses: actions/download-artifact@v4
         with:
           name: unit-report
           path: dist/reports/unit
-          run-id: \${{ github.event.workflow_run.id }}
-          github-token: \${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
       - name: Download Playwright Report
@@ -63,8 +76,8 @@ jobs:
         with:
           name: playwright-report
           path: dist/reports/e2e
-          run-id: \${{ github.event.workflow_run.id }}
-          github-token: \${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
       - name: Generate reports index
@@ -93,17 +106,17 @@ jobs:
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks
         with:
-          repoToken: '\${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '\${{ secrets.FIREBASE_SERVICE_ACCOUNT_VOTE_COUNTER_C8CD5 }}'
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_VOTE_COUNTER_C8CD5 }}'
           projectId: vote-counter-c8cd5
-          channelId: pr-\${{ steps.pr_info.outputs.number }}
+          channelId: pr-${{ steps.pr_info.outputs.number }}
           expires: 7d
 
       - name: Post combined report comment
         uses: actions/github-script@v7
         env:
-          PREVIEW_URL: \${{ steps.deploy.outputs.details_url }}
-          PR_NUMBER: \${{ steps.pr_info.outputs.number }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.details_url }}
+          PR_NUMBER: ${{ steps.pr_info.outputs.number }}
         with:
           script: |
             const marker = '🚀 Preview deployment ready';


### PR DESCRIPTION
Switched from head-based PR matching to SHA-based matching using `listPullRequestsAssociatedWithCommit`. This is much more reliable for `workflow_run` events.