### PR TITLE
fix(ci): restore firebase.json for preview deployment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -35,6 +35,10 @@ jobs:
               core.setFailed('No open PR found for this run');
             }
 
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
       - name: Download Dist Artifact
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
This PR fixes the 'firebase.json not found' error in the  workflow.

- **Problem**: Removing checkout meant  was missing, which is required by the Firebase deploy action.
- **Solution**: Restored  but specifically checking out the trusted  branch. This provides the configuration file without executing untrusted code from the PR branch (preserving security).